### PR TITLE
add auto-update container option to the joplin server container

### DIFF
--- a/systemd/joplin-server.container
+++ b/systemd/joplin-server.container
@@ -5,6 +5,7 @@ WantedBy=default.target
 Image=docker.io/joplin/server:latest
 ContainerName=joplin-server
 Network=joplin.network
+AutoUpdate=registry
 PublishPort=22300:22300
 Environment=APP_BASE_URL=https://notes.danvergara.com
 Environment=APP_PORT=22300


### PR DESCRIPTION
## Changes

This PR add `AutoUpdate=registry` to the joplin server container file which is equal to add `--label io.containers.autoupdate=registry` to the `$ podman run/create` command. This enables the [auto-update feature](https://www.redhat.com/sysadmin/podman-auto-updates-rollbacks) that makes sure to pull the newest image available on the registry every 24 hours. If Podman fails to spin up the new container, will perform a rollback to the previous image version.