### PR TITLE
Fix dashes on commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: quadlet-dry-run
 ## rm-systemd: Run quadlet executable in dry-run mode 
 quadlet-dry-run:
-	/usr/libexec/podman/quadlet -dryrun -user
+	/usr/libexec/podman/quadlet --dryrun --user
 
 .PHONY: rm-systemd
 ## rm-systemd: Delete all the content in the systemd dir
@@ -21,7 +21,7 @@ reload:
 .PHONY: start
 ## start: start the joplin service
 start:
-	systemctl –user start joplin-server.service
+	systemctl --user start joplin-server.service
 
 .PHONY: help
 ## help: Prints this help message


### PR DESCRIPTION
This PR fixes some target commands on the `Makefile`. It seems commands got misformatted when I copied and pasted from the original web.